### PR TITLE
Propagate physical wavenumber into AIEM multiple scattering

### DIFF
--- a/src/ssrt/core.py
+++ b/src/ssrt/core.py
@@ -219,6 +219,9 @@ class S2RTR:
                     eri=float(np.imag(eps_surface)),
                     itype=itype,
                     add_multiple=False,
+                    k0=k,
+                    sigma=float(self.s),
+                    corr_len=float(self.cl),
                 )
                 sig_s = {
                     'vv': toPower(vv_db),
@@ -318,6 +321,9 @@ class S2RTR:
                     eri=float(np.imag(eps_top)),
                     itype=itype,
                     add_multiple=False,
+                    k0=k,
+                    sigma=float(self.s),
+                    corr_len=float(self.cl),
                 )
                 sig_0_top = {
                     'vv': toPower(vv_top_db),
@@ -337,6 +343,9 @@ class S2RTR:
                     eri=float(np.imag(eps_bot)),
                     itype=itype,
                     add_multiple=False,
+                    k0=k,
+                    sigma=float(self.s),
+                    corr_len=float(self.cl),
                 )
                 sig_0_bot = {
                     'vv': toPower(vv_bot_db),

--- a/test/test_aiem.py
+++ b/test/test_aiem.py
@@ -143,6 +143,9 @@ def _run_comparison(
             float(eps_i),
             surface_type,
             addMultiple=include_multiple,
+            k0=k,
+            sigma=sigma,
+            corr_len=corr_len,
         )
 
         overall_model["hh"].append(hh_db)


### PR DESCRIPTION
## Summary
- add optional physical-parameter fields to `AIEMParameters` and require a real wavenumber when multiple scattering is requested
- forward the real wavenumber, RMS height, and correlation length into the multiple-scattering integrator and update its quadrature/spectrum scaling
- update AIEM call sites and regression harness to provide the new parameters

## Testing
- `PYTHONPATH=src python3 test/test_aiem.py --add-multiple --per-ratio`


------
https://chatgpt.com/codex/tasks/task_e_68dbf47b154483309e4b2ada5ccfe569